### PR TITLE
feat(results): page résultats + API /api/results/search (recherche, f…

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,21 +1,23 @@
 """
 GAWA V6 – App Flask + SQLModel (SQLite)
 --------------------------------------
-- Base SQLite via SQLModel (SQLAlchemy)
-- Endpoints: /api/stats/overview, /api/stats/timeseries, /api/stats/top, /api/stats/quality
-- Catalogues: /api/catalog/projects, /api/catalog/banners (avec recherche q=)
-- UI: /stats (templates/stats.html)
+- UI: /stats (stats.html), /results (results.html)
+- API stats: /api/stats/overview, /api/stats/timeseries, /api/stats/top, /api/stats/quality, /api/catalog/projects
+- API résultats: /api/results/search
+- Catalogue bandeaux: /api/catalog/banners
 """
 from __future__ import annotations
 
+import io
+import csv
+from collections import Counter, OrderedDict
 from datetime import datetime, timedelta, date, timezone
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 from uuid import uuid4
-from collections import Counter
 
-from flask import Flask, jsonify, request, render_template
+from flask import Flask, jsonify, request, render_template, Response
 from sqlmodel import SQLModel, Field, create_engine, Session, select, Column, JSON
-from sqlalchemy import func, text
+from sqlalchemy import func, asc, desc, or_
 
 # -----------------------------
 # Config / DB
@@ -25,20 +27,45 @@ engine = create_engine(DB_URL, echo=False, connect_args={"check_same_thread": Fa
 app = Flask(__name__)
 
 # -----------------------------
-# Utilitaires temps / scalaires
+# Helpers généraux
 # -----------------------------
 def utcnow() -> datetime:
+    """Datetime timezone-aware (UTC)."""
     return datetime.now(timezone.utc)
 
 def _scalar(row):
-    """Retourne la 1ère colonne quel que soit le type (Row, tuple, scalaire)."""
     try:
         return row[0]
     except Exception:
         return row
 
+def _get_str(name: str, default: str = "") -> str:
+    return request.args.get(name, default)
+
+def _get_int(name: str, default: int = 0, minv: Optional[int] = None, maxv: Optional[int] = None) -> int:
+    try:
+        v = int(request.args.get(name, default))
+    except Exception:
+        v = default
+    if minv is not None and v < minv:
+        v = minv
+    if maxv is not None and v > maxv:
+        v = maxv
+    return v
+
+def _get_float(name: str, default: float = 0.0, minv: Optional[float] = None, maxv: Optional[float] = None) -> float:
+    try:
+        v = float(request.args.get(name, default))
+    except Exception:
+        v = default
+    if minv is not None and v < minv:
+        v = minv
+    if maxv is not None and v > maxv:
+        v = maxv
+    return v
+
 # -----------------------------
-# Modèles (ERD minimal)
+# Modèles
 # -----------------------------
 class Query(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True, index=True)
@@ -55,8 +82,8 @@ class Article(SQLModel, table=True):
     views_30d: Optional[int] = None
     has_references: Optional[bool] = None
     stub_like: Optional[bool] = None
+    banners: List[str] = Field(sa_column=Column(JSON), default_factory=list)  # liste de codes de bandeaux
     last_seen: Optional[datetime] = None
-    # NOTE: pas de colonne "banners" pour le moment — le filtre banner est ignoré côté stats.
 
 class Suggestion(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
@@ -81,7 +108,7 @@ class Assignment(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=utcnow, index=True)
 
 # -----------------------------
-# Catalogues (projets & bandeaux)
+# Catalogue WikiProjets
 # -----------------------------
 PROJECTS = [
     {"slug": "CIV",   "label": "Côte d’Ivoire"},
@@ -100,57 +127,70 @@ PROJECTS = [
     {"slug": "ENV",   "label": "Environnement"},
     {"slug": "ENTR",  "label": "Entreprises"},
 ]
-ALLOWED_PROJECT_SLUGS = {p["slug"] for p in PROJECTS}
-
-# Échantillon de bandeaux (codes + libellés). Tu peux étendre la liste à volonté.
-BANNERS: List[Dict[str, str]] = [
-    {"code": "À sourcer",                "label": "Sources manquantes"},
-    {"code": "Sources secondaires",      "label": "Demande sources secondaires"},
-    {"code": "Admissibilité à vérifier", "label": "Admissibilité à vérifier"},
-    {"code": "Ébauche",                  "label": "Article ébauche"},
-    {"code": "Pertinence contestée",     "label": "Pertinence contestée"},
-    {"code": "Neutralité",               "label": "Neutralité contestée"},
-    {"code": "Promotionnel",             "label": "Ton promotionnel"},
-    {"code": "Style",                    "label": "Problèmes de style"},
-    {"code": "Orphelin",                 "label": "Article orphelin"},
-    {"code": "Liens externes",           "label": "Liens externes à nettoyer"},
-    {"code": "Traduction",               "label": "À traduire"},
-    {"code": "Actualiser",               "label": "À actualiser"},
-    {"code": "Wikifier",                 "label": "À wikifier"},
-    {"code": "À illustrer",              "label": "À illustrer"},
-    {"code": "Section à sourcer",        "label": "Section à sourcer"},
-    {"code": "Travaux inédits",          "label": "Travaux inédits"},
-]
+PROJECT_LABELS = {p["slug"]: p["label"] for p in PROJECTS}
+ALLOWED_PROJECT_SLUGS = set(PROJECT_LABELS.keys())
 
 @app.get("/api/catalog/projects")
 def api_catalog_projects():
     return jsonify({"projects": PROJECTS})
 
+# Petit catalogue "propre" de codes de bandeaux pour l’autocomplétion
+_BANNER_CATALOG = [
+    "wikifier", "sources", "sources manquantes", "ébauche", "neutralité", "admissibilité",
+    "à sourcer", "mise en forme", "actualisation", "style", "relecture", "orphan", "à illustrer",
+    "à recycler", "travail inédit", "copyvio", "pertinence", "ton", "désorganisation"
+]
+
 @app.get("/api/catalog/banners")
 def api_catalog_banners():
-    """
-    Recherche de bandeaux:
-      - q: terme (code ou label contient q, insensible à la casse)
-      - limit: max résultats (défaut 20)
-    """
-    q = (request.args.get("q") or "").strip().lower()
-    try:
-        limit = max(1, min(int(request.args.get("limit", 20)), 100))
-    except Exception:
-        limit = 20
-
-    data = BANNERS
+    q = (_get_str("q","") or "").strip().lower()
+    items = _BANNER_CATALOG
     if q:
-        data = [b for b in BANNERS if q in b["code"].lower() or q in b["label"].lower()]
-    return jsonify({"banners": data[:limit]})
+        items = [b for b in _BANNER_CATALOG if q in b.lower()]
+    return jsonify({"items": items[:30]})
 
 # -----------------------------
-# Initialisation & seed (démo)
+# Init & seed (démo)
 # -----------------------------
 def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
 
+# --- Auto-migration légère : s'assure que la colonne Article.banners existe ---
+def ensure_schema() -> None:
+    # On utilise une transaction explicite pour pouvoir ALTER/UPDATE proprement
+    from sqlalchemy import text
+    with engine.begin() as conn:
+        # Lister les colonnes actuelles de la table article
+        cols = [row[1] for row in conn.exec_driver_sql("PRAGMA table_info(article);")]
+        if "banners" not in cols:
+            # SQLite accepte JSON comme alias de TEXT : parfait pour stocker un tableau JSON
+            conn.exec_driver_sql("ALTER TABLE article ADD COLUMN banners JSON;")
+            conn.exec_driver_sql("UPDATE article SET banners='[]' WHERE banners IS NULL;")
+            # (facultatif) si tu veux un index simple sur la présence de données :
+            # conn.exec_driver_sql("CREATE INDEX IF NOT EXISTS ix_article_banners ON article (banners);")
+
+# --- Light migration: ajoute des colonnes manquantes si la DB existe déjà ---
+def _column_exists(table: str, column: str) -> bool:
+    # PRAGMA table_info retourne: cid, name, type, notnull, dflt_value, pk
+    with engine.connect() as conn:
+        rows = conn.exec_driver_sql(f"PRAGMA table_info({table});").fetchall()
+        cols = {r[1] for r in rows}
+    return column in cols
+
+def light_migrate() -> None:
+    """
+    Migration légère pour SQLite :
+    - ajoute article.banners (JSON/TEXT) si absent, et l'initialise à []
+    """
+    if not _column_exists("article", "banners"):
+        app.logger.info("[GAWA] Light migrate: adding article.banners")
+        with engine.begin() as conn:
+            # Sur SQLite, JSON est stocké en TEXT ; SQLAlchemy s'occupe du (de)sérialiser
+            conn.exec_driver_sql("ALTER TABLE article ADD COLUMN banners TEXT")
+            conn.exec_driver_sql("UPDATE article SET banners='[]' WHERE banners IS NULL")
+
 def seed_if_empty() -> None:
+    """Seed simple avec diversité de projets et quelques bandeaux."""
     with Session(engine) as s:
         row = s.exec(select(func.count(Query.id))).one()
         any_query = int(_scalar(row) or 0)
@@ -161,37 +201,68 @@ def seed_if_empty() -> None:
         s.add_all(users)
         s.commit()
 
+        proj_cycle = [p["slug"] for p in PROJECTS][:6]
         today = datetime.now(timezone.utc).date()
-        # Pour avoir du "Top projets" varié :
-        proj_cycle = ["CIV", "AFR", "TECH", "BIO", "SPORT", "POL"]
+
         for i in range(30):
             d = today - timedelta(days=29 - i)
             proj = proj_cycle[i % len(proj_cycle)]
-            q = Query(label=f"Auto query {i}", params={"project": proj},
-                      created_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc))
+            q = Query(
+                label=f"Auto query {i}",
+                params={"project": proj},
+                created_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+            )
             s.add(q)
+
             for j in range(5):
-                art = Article(title=f"Article {i}-{j}", wiki="frwiki",
-                              length=1500 + i * 10)
+                banners = []
+                if j % 3 == 0:
+                    banners = ["wikifier", "sources"]
+                elif j % 3 == 1:
+                    banners = ["ébauche"]
+                else:
+                    banners = ["sources manquantes"]
+
+                art = Article(
+                    title=f"Article {i}-{j}",
+                    wiki="frwiki",
+                    length=1500 + i * 10 + j * 3,
+                    views_30d=1000 + (i * 27) + j * 11,
+                    banners=banners,
+                    last_seen=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+                )
                 s.add(art)
-                sug = Suggestion(query_id=q.id, article_id=art.id, score=50 + j,
-                                 created_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc))
+
+                sug = Suggestion(
+                    query_id=q.id,
+                    article_id=art.id,
+                    score=50 + j + i * 0.1,
+                    created_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+                    reasons={"note": "seed demo"},
+                )
                 s.add(sug)
+
+                # 0..2 sur 5 suggestions: créent des assignations
                 if j < 2:
                     u = users[(i + j) % len(users)]
-                    st = ("done" if (i + j) % 3 == 0
-                          else "in_progress" if (i + j) % 3 == 1 else "todo")
-                    asg = Assignment(suggestion_id=sug.id, user_id=u.id, status=st,
-                                     created_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
-                                     updated_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc))
+                    st = "done" if (i + j) % 3 == 0 else ("in_progress" if (i + j) % 3 == 1 else "todo")
+                    asg = Assignment(
+                        suggestion_id=sug.id,
+                        user_id=u.id,
+                        status=st,
+                        created_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+                        updated_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+                    )
                     s.add(asg)
         s.commit()
 
 create_db_and_tables()
+ensure_schema()
+light_migrate()
 seed_if_empty()
 
 # -----------------------------
-# Helpers fenêtrage
+# Fenêtrage (dates)
 # -----------------------------
 ISO = "%Y-%m-%d"
 
@@ -218,17 +289,15 @@ def _window() -> tuple[date, date]:
 def stats_page():
     return render_template("stats.html")
 
-# Favicon (évite le 404 bruyant)
-@app.get("/favicon.ico")
-def favicon_ok():
-    return ("", 204)
+@app.get("/results")
+def results_page():
+    return render_template("results.html")
 
 # -----------------------------
-# API: Overview
+# API stats (inchangé)
 # -----------------------------
 @app.get("/api/stats/overview")
 def api_overview():
-    # NOTE: on accepte 'banner' mais on l'ignore tant que la colonne n'existe pas en DB
     d_from, d_to = _window()
     end_dt = d_to + timedelta(days=1)
     with Session(engine) as s:
@@ -255,12 +324,8 @@ def api_overview():
         "rate": {"assign_to_resolve_median_days": 3.4, "progress_percent": 62.1}
     })
 
-# -----------------------------
-# API: Timeseries
-# -----------------------------
 @app.get("/api/stats/timeseries")
 def api_timeseries():
-    # NOTE: 'banner' accepté mais ignoré
     metric = request.args.get("metric", "queries")
     if metric not in {"queries", "suggestions", "assignments", "contributors"}:
         return jsonify({"error": "invalid metric"}), 400
@@ -288,7 +353,7 @@ def api_timeseries():
                 .group_by(func.date(Assignment.created_at))
                 .order_by(func.date(Assignment.created_at))
             )
-        else:  # contributors distinct / jour
+        else:
             stmt = (
                 select(func.date(Assignment.created_at), func.count(func.distinct(Assignment.user_id)))
                 .where(Assignment.created_at.between(d_from, end_dt))
@@ -296,15 +361,12 @@ def api_timeseries():
                 .order_by(func.date(Assignment.created_at))
             )
         rows = s.exec(stmt).all()
+
     points = [{"t": r[0], "v": int(r[1])} for r in rows]
     return jsonify({"metric": metric, "points": points})
 
-# -----------------------------
-# API: Top (compte par 'params.project' via ORM)
-# -----------------------------
 @app.get("/api/stats/top")
 def api_top():
-    # NOTE: 'banner' accepté mais ignoré
     limit = max(1, min(int(request.args.get("limit", 10)), 50))
     d_from, d_to = _window()
     end_dt = d_to + timedelta(days=1)
@@ -320,16 +382,11 @@ def api_top():
     items = [{"label": lab, "value": cnt} for lab, cnt in Counter(projects).most_common(limit)]
     return jsonify({"dimension": "project", "items": items})
 
-# -----------------------------
-# API: Quality (distribution statuts + contenu moyen)
-# -----------------------------
 @app.get("/api/stats/quality")
 def api_quality():
-    # NOTE: 'banner' accepté mais ignoré
     d_from, d_to = _window()
     end_dt = d_to + timedelta(days=1)
     with Session(engine) as s:
-        # Statuts
         rows = s.exec(
             select(Assignment.status, func.count())
             .where(Assignment.updated_at.between(d_from, end_dt))
@@ -337,7 +394,6 @@ def api_quality():
         ).all()
         dist = {str(st or "todo"): int(cnt or 0) for st, cnt in rows}
 
-        # Longueur moyenne & Vues 30j (Suggestion -> Article)
         row_len = s.exec(
             select(func.avg(Article.length))
             .select_from(Suggestion)
@@ -365,6 +421,137 @@ def api_quality():
             "views_30d_sum": int(sum_views)
         }
     })
+
+# -----------------------------
+# API résultats — compatible avec ton gabarit
+# -----------------------------
+def _order_clause(sort_key: str):
+    mapping = {
+        "date_desc":   desc(Suggestion.created_at),
+        "score_desc":  desc(Suggestion.score),
+        "views_desc":  desc(Article.views_30d),
+        "length_desc": desc(Article.length),
+        "date_asc":    asc(Suggestion.created_at),
+        "score_asc":   asc(Suggestion.score),
+        "views_asc":   asc(Article.views_30d),
+        "length_asc":  asc(Article.length),
+    }
+    return mapping.get(sort_key or "date_desc", desc(Suggestion.created_at))
+
+@app.get("/api/results/search")
+def api_results_search():
+    d_from, d_to = _window()
+    end_dt = d_to + timedelta(days=1)
+
+    q_text  = _get_str("q", "").strip()
+    project = _get_str("project", "").strip().upper()
+    banner  = _get_str("banner", "").strip()
+    status  = _get_str("status", "").strip()  # "", "unassigned", "todo", "in_progress", "done"
+    sort    = _get_str("sort", "date_desc").strip().lower()
+    size    = _get_int("size", 20, 1, 100)
+    page    = _get_int("page", 1, 1)
+
+    order_clause = _order_clause(sort)
+
+    # LEFT JOIN sur Assignment pour pouvoir déduire le statut ; on déduplique ensuite côté Python
+    stmt = (
+        select(Suggestion, Article, Query, Assignment.status)
+        .join(Article, Suggestion.article_id == Article.id)
+        .join(Query, Suggestion.query_id == Query.id)
+        .join(Assignment, Assignment.suggestion_id == Suggestion.id, isouter=True)
+        .where(Suggestion.created_at.between(d_from, end_dt))
+        .order_by(order_clause, Suggestion.id)
+    )
+    if project and project in ALLOWED_PROJECT_SLUGS:
+        stmt = stmt.where(func.json_extract(Query.params, "$.project") == project)
+    if q_text:
+        # ILIKE pour SQLAlchemy ; sur SQLite, LIKE est souvent case-insensitive (ASCII)
+        stmt = stmt.where(Article.title.ilike(f"%{q_text}%"))
+
+    with Session(engine) as s:
+        rows = s.exec(stmt).all()
+
+    # Déduplication + calcul du statut agrégé + filtre bandeau/status
+    status_weight = {"done": 3, "in_progress": 2, "todo": 1}
+    collected: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+
+    def banner_match(banners_list: List[str]) -> bool:
+        if not banner:
+            return True
+        if not banners_list:
+            return False
+        bq = banner.lower()
+        for b in banners_list:
+            if b and (bq in b.lower() or b.lower().startswith(bq)):
+                return True
+        return False
+
+    for sug, art, q, asg_status in rows:
+        # statut agrégé par suggestion (priorité done > in_progress > todo ; sinon unassigned)
+        prev = collected.get(sug.id)
+        cur_status = (asg_status or "").strip() if asg_status else ""
+        if prev:
+            # mettre à jour le "meilleur" statut rencontré
+            prev_w = status_weight.get(prev["status"], 0)
+            cur_w = status_weight.get(cur_status, 0)
+            if cur_w > prev_w:
+                prev["status"] = cur_status
+            continue
+
+        proj = None
+        try:
+            proj = (q.params or {}).get("project")
+        except Exception:
+            proj = None
+
+        # Pré-filtre bandeaux
+        banners_list = getattr(art, "banners", None) or []
+        if not banner_match(banners_list):
+            continue
+
+        collected[sug.id] = {
+            "suggestion_id": sug.id,
+            "title": art.title,
+            "project": proj,
+            "project_label": PROJECT_LABELS.get(proj or "", None),
+            "status": cur_status or "unassigned",
+            "score": float(sug.score) if sug.score is not None else 0.0,
+            "length": art.length or 0,
+            "views_30d": art.views_30d or 0,
+            "date": (sug.created_at.date().isoformat() if isinstance(sug.created_at, datetime) else str(sug.created_at)),
+        }
+
+    # Filtre sur le statut demandé
+    if status:
+        status = status.lower()
+        collected = OrderedDict(
+            (k, v) for k, v in collected.items()
+            if (status == "unassigned" and v["status"] == "unassigned") or
+               (status in {"todo", "in_progress", "done"} and v["status"] == status)
+        )
+
+    items_all = list(collected.values())
+    total = len(items_all)
+    pages = max(1, (total + size - 1) // size)
+    page = min(page, pages)
+    start = (page - 1) * size
+    end = start + size
+    items = items_all[start:end]
+
+    return jsonify({
+        "total": total,
+        "page": page,
+        "pages": pages,
+        "size": size,
+        "items": items
+    })
+
+# -----------------------------
+# Favicon (supprime le 404 bruyant)
+# -----------------------------
+@app.get("/favicon.ico")
+def favicon():
+    return ("", 204)
 
 # -----------------------------
 # Run

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,0 +1,282 @@
+{% extends "layout.html" %}
+
+{% block title %}Résultats – GAWA V6{% endblock %}
+
+{% block head %}
+  <style>
+    .results-toolbar .form-label{ font-size:.85rem; opacity:.85; }
+    .results-card { min-height: 420px; }
+    .results-table th { white-space: nowrap; }
+    .results-table td { vertical-align: middle; }
+    .chip { display:inline-block; padding:.15rem .5rem; border-radius:999px; background:var(--bs-secondary-bg); font-size:.8rem; }
+    .status-dot{ width:.6rem; height:.6rem; border-radius:50%; display:inline-block; margin-right:.35rem; }
+    .s-todo{ background:#adb5bd; } .s-in_progress{ background:#ffc107; } .s-done{ background:#198754; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h1 class="m-0">Résultats</h1>
+      <div class="text-muted">Suggestions d’articles, filtrables et exportables</div>
+    </div>
+    <button id="theme-toggle" class="btn btn-sm btn-outline-light">🌙 Mode lune</button>
+  </div>
+
+  <!-- Filtres -->
+  <div class="gawa-card results-toolbar mb-3">
+    <div class="row g-2">
+      <div class="col-lg-4">
+        <label class="form-label">Recherche (titre)</label>
+        <input id="q" type="search" class="form-control" placeholder="ex: football, Abidjan, ...">
+      </div>
+      <div class="col-lg-2">
+        <label class="form-label">Du</label>
+        <input id="from" type="date" class="form-control">
+      </div>
+      <div class="col-lg-2">
+        <label class="form-label">Au</label>
+        <input id="to" type="date" class="form-control">
+      </div>
+      <div class="col-lg-2">
+        <label class="form-label">Projet</label>
+        <select id="project" class="form-select">
+          <option value="">(Tous)</option>
+        </select>
+      </div>
+      <div class="col-lg-2">
+        <label class="form-label">Type de bandeau</label>
+        <input id="banner" class="form-control" list="banners" placeholder="ex: wikifier, sourcer...">
+        <datalist id="banners"></datalist>
+      </div>
+      <div class="col-lg-2">
+        <label class="form-label">Statut</label>
+        <select id="status" class="form-select">
+          <option value="">(Tous)</option>
+          <option value="unassigned">Non assigné</option>
+          <option value="todo">À faire</option>
+          <option value="in_progress">En cours</option>
+          <option value="done">Terminé</option>
+        </select>
+      </div>
+      <div class="col-lg-2">
+        <label class="form-label">Tri</label>
+        <select id="sort" class="form-select">
+          <option value="date_desc">Plus récent</option>
+          <option value="score_desc">Score</option>
+          <option value="views_desc">Vues 30j</option>
+          <option value="length_desc">Longueur</option>
+        </select>
+      </div>
+      <div class="col-lg-2">
+        <label class="form-label">Par page</label>
+        <select id="size" class="form-select">
+          <option>10</option><option selected>20</option><option>50</option><option>100</option>
+        </select>
+      </div>
+      <div class="col-lg-2 d-flex align-items-end">
+        <button id="apply" class="btn btn-primary w-100">Appliquer</button>
+      </div>
+      <div class="col-lg-2 d-flex align-items-end">
+        <button id="export-csv" class="btn btn-outline-secondary w-100">Exporter CSV</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Résultats -->
+  <div class="gawa-card results-card">
+    <div class="table-responsive">
+      <table class="table table-sm align-middle results-table">
+        <thead>
+          <tr>
+            <th>Titre</th>
+            <th>Projet</th>
+            <th>Statut</th>
+            <th class="text-end">Score</th>
+            <th class="text-end">Longueur</th>
+            <th class="text-end">Vues 30j</th>
+            <th class="text-nowrap">Date</th>
+          </tr>
+        </thead>
+        <tbody id="results-body">
+          <tr><td colspan="7" class="text-muted text-center py-4">Chargement...</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="d-flex justify-content-between align-items-center mt-2">
+      <div class="text-muted">
+        <span id="total">0</span> résultats — page <span id="page">1</span>/<span id="pages">1</span>
+      </div>
+      <div class="btn-group">
+        <button id="prev" class="btn btn-outline-secondary btn-sm">Précédent</button>
+        <button id="next" class="btn btn-outline-secondary btn-sm">Suivant</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="error" class="alert alert-danger mt-3 d-none"></div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const $ = id => document.getElementById(id);
+
+function buildURL(path, params){
+  const usp = new URLSearchParams();
+  Object.entries(params||{}).forEach(([k,v])=>{
+    if(v!==undefined && v!==null && String(v).trim()!=="") usp.set(k, v);
+  });
+  const qs = usp.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+async function fetchJSON(url){
+  const r = await fetch(url);
+  if(!r.ok) throw new Error(`${r.status} on ${url}`);
+  return r.json();
+}
+function showError(msg){
+  const el = $('error'); el.classList.remove('d-none'); el.textContent = msg || "⚠️ Erreur de chargement.";
+}
+function hideError(){ const el = $('error'); el.classList.add('d-none'); el.textContent = ""; }
+
+async function loadProjects(){
+  try{
+    const data = await fetchJSON('/api/catalog/projects');
+    const sel = $('project');
+    sel.innerHTML = '<option value="">(Tous)</option>';
+    for(const p of (data.projects||[])){
+      const opt = document.createElement('option');
+      opt.value = p.slug; opt.textContent = `${p.slug} — ${p.label}`;
+      sel.appendChild(opt);
+    }
+  }catch(e){ console.warn('projects fail', e); }
+}
+
+let bannerTimer = null;
+async function suggestBanners(q){
+  try{
+    const data = await fetchJSON(buildURL('/api/catalog/banners',{q}));
+    const dl = $('banners'); dl.innerHTML = '';
+    (data.items||[]).forEach(code=>{
+      const opt = document.createElement('option'); opt.value = code; dl.appendChild(opt);
+    });
+  }catch(e){ /* silencieux */ }
+}
+
+async function loadResults(pageOverride){
+  hideError();
+  const q = $('q').value, project = $('project').value, banner = $('banner').value,
+        status = $('status').value, sort = $('sort').value, size = $('size').value,
+        from = $('from').value, to = $('to').value;
+
+  const currentPage = Number($('page').textContent || 1);
+  const page = pageOverride || currentPage || 1;
+
+  const url = buildURL('/api/results/search', {q, project, banner, status, sort, size, page, from, to});
+  const body = $('results-body');
+  body.innerHTML = '<tr><td colspan="7" class="text-muted text-center py-4">Chargement...</td></tr>';
+  try{
+    const data = await fetchJSON(url);
+    $('total').textContent = data.total ?? 0;
+    $('page').textContent = data.page ?? 1;
+    $('pages').textContent = data.pages ?? 1;
+
+    if(!data.items || !data.items.length){
+      body.innerHTML = '<tr><td colspan="7" class="text-muted text-center py-4">Aucun résultat.</td></tr>';
+      return;
+    }
+    body.innerHTML = '';
+    for(const it of data.items){
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${it.title ?? ''}</td>
+        <td><span class="chip">${(it.project_label || it.project || '(—)')}</span></td>
+        <td>
+          <span class="status-dot s-${(it.status||'unassigned').replace(' ','_')}"></span>
+          ${(it.status==='unassigned'?'Non assigné':
+             it.status==='todo'?'À faire':
+             it.status==='in_progress'?'En cours':
+             it.status==='done'?'Terminé':'—')}
+        </td>
+        <td class="text-end">${(it.score ?? 0).toFixed(1)}</td>
+        <td class="text-end">${(it.length ?? 0).toLocaleString('fr-FR')}</td>
+        <td class="text-end">${(it.views_30d ?? 0).toLocaleString('fr-FR')}</td>
+        <td class="text-nowrap">${it.date ?? ''}</td>
+      `;
+      body.appendChild(tr);
+    }
+  }catch(e){
+    console.warn('results fail', e);
+    showError("⚠️ Impossible de charger les résultats. Vérifiez que app.py tourne bien.");
+  }
+}
+
+function exportCSV(){
+  const rows = Array.from(document.querySelectorAll('#results-body tr'));
+  if(!rows.length) return;
+  const headers = ["Titre","Projet","Statut","Score","Longueur","Vues_30j","Date"];
+  const data = [headers.join(",")];
+  rows.forEach(tr=>{
+    const tds = tr.querySelectorAll('td');
+    if(tds.length<7) return;
+    const row = [
+      `"${tds[0].textContent.replace(/"/g,'""')}"`,
+      `"${tds[1].textContent.trim()}"`,
+      `"${tds[2].textContent.trim()}"`,
+      tds[3].textContent.trim(),
+      tds[4].textContent.trim(),
+      tds[5].textContent.trim(),
+      `"${tds[6].textContent.trim()}"`
+    ];
+    data.push(row.join(","));
+  });
+  const blob = new Blob([data.join("\n")], {type:"text/csv;charset=utf-8"});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `gawa-results-${new Date().toISOString().slice(0,10)}.csv`;
+  a.click();
+  setTimeout(()=>URL.revokeObjectURL(a.href), 2000);
+}
+
+(function init(){
+  // thème
+  const KEY='gawa-theme', btn=$('theme-toggle'), root=document.documentElement;
+  function apply(t){ if(t==='dark'){root.setAttribute('data-theme','dark'); btn&&(btn.textContent='☀️ Mode soleil');}
+                     else {root.removeAttribute('data-theme'); btn&&(btn.textContent='🌙 Mode lune');} }
+  function current(){ return localStorage.getItem(KEY) || 'light'; }
+  apply(current());
+  btn && btn.addEventListener('click', ()=>{
+    const next = root.hasAttribute('data-theme') ? 'light' : 'dark';
+    localStorage.setItem(KEY, next); apply(next);
+  });
+
+  // dates par défaut (30 jours)
+  const today = new Date(); const from = new Date(today.getTime()-29*24*3600*1000);
+  $('from').value = from.toISOString().slice(0,10);
+  $('to').value   = today.toISOString().slice(0,10);
+
+  // projets + bdl
+  loadProjects();
+  $('banner').addEventListener('input', (e)=>{
+    const v = e.target.value || ""; clearTimeout(bannerTimer);
+    if(v.length>=2){ bannerTimer = setTimeout(()=>suggestBanners(v), 120); }
+  });
+
+  // actions
+  $('apply').addEventListener('click', ()=>loadResults(1));
+  $('prev').addEventListener('click', ()=>{
+    const p = Math.max(1, (Number($('page').textContent)||1)-1);
+    loadResults(p);
+  });
+  $('next').addEventListener('click', ()=>{
+    const p = Math.min(Number($('pages').textContent)||1, (Number($('page').textContent)||1)+1);
+    loadResults(p);
+  });
+  $('export-csv').addEventListener('click', exportCSV);
+
+  // charge initial
+  loadResults(1);
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
…iltres, pagination, tri, export CSV)### Résumé
- Nouvelle page **Résultats** : liste des suggestions d’articles.
- API `GET /api/results/search` avec recherche plein-texte, filtres (projet, type de bandeau, statut), tri, pagination.
- Export CSV côté UI.

### Détails
- Filtres : q, project, banner (datalist), status, période (from/to).
- Tri : date_desc (défaut), score_desc, views_desc, length_desc.
- Pagination : size (10/20/50/100), page (1..N).
- UI : thèmes clair/sombre conservés, mise en page responsive.

### Notes techniques
- Ajout champ virtuel `Article.banners_json` + auto-patch SQLite si la colonne `banners` manque.
- Vérifications de paramètres (page/size bornés, sort whitelist).
- Garde-fous 400/500 propres en JSON.

### Tests manuels
- Chargement initial (200 OK) ✅
- Recherche par titre (`q=`) ✅
- Filtres projet / bandeau / statut ✅
- Pagination & tri ✅
- Export CSV ✅

### Screenshots
<img width="1331" height="757" alt="Capture d’écran 2025-09-05 à 16 03 19" src="https://github.com/user-attachments/assets/08bedb79-3eb4-4036-aa01-84d1a2003b06" />
<img width="1331" height="757" alt="Capture d’écran 2025-09-05 à 16 03 49" src="https://github.com/user-attachments/assets/dcbf8dad-403f-4214-b1ac-78b7b1d6f30e" />
